### PR TITLE
Update README contents for TAssist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
+# TAssist
 [![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
 [![codecov](https://codecov.io/gh/CS2103-F15-4/tp/graph/badge.svg?token=W9PDYP0LF3)](https://codecov.io/gh/CS2103-F15-4/tp)
 
 ![Ui](docs/images/Ui.png)
+  
+## Introduction
+TAssist is a keyboard-driven software catered for NUS teaching assistants to streamline the management of tutorial groups.
+    
+## Features
+_Coming soon._
+  
+## Documentation
+* For the detailed documentation of this project, see the **[TAssist Website](https://ay2425s2-cs2103-f15-4.github.io/tp/)**.
 
-* This is **a sample project for Software Engineering (SE) students**.<br>
-  Example usages:
-  * as a starting point of a course project (as opposed to writing everything from scratch)
-  * as a case study
-* The project simulates an ongoing software project for a desktop application (called _AddressBook_) used for managing contact details.
-  * It is **written in OOP fashion**. It provides a **reasonably well-written** code base **bigger** (around 6 KLoC) than what students usually write in beginner-level SE modules, without being overwhelmingly big.
-  * It comes with a **reasonable level of user and developer documentation**.
-* It is named `AddressBook Level 3` (`AB3` for short) because it was initially created as a part of a series of `AddressBook` projects (`Level 1`, `Level 2`, `Level 3` ...).
-* For the detailed documentation of this project, see the **[Address Book Product Website](https://se-education.org/addressbook-level3)**.
-* This project is a **part of the se-education.org** initiative. If you would like to contribute code to this project, see [se-education.org](https://se-education.org/#contributing-to-se-edu) for more info.
+## Additional Information

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 [![codecov](https://codecov.io/gh/CS2103-F15-4/tp/graph/badge.svg?token=W9PDYP0LF3)](https://codecov.io/gh/CS2103-F15-4/tp)
 
 ![Ui](docs/images/Ui.png)
-  
+
 ## Introduction
 TAssist is a keyboard-driven software catered for NUS teaching assistants to streamline the management of tutorial groups.
-    
+
 ## Features
 _Coming soon._
-  
+
 ## Documentation
 * For the detailed documentation of this project, see the **[TAssist Website](https://ay2425s2-cs2103-f15-4.github.io/tp/)**.
-
+* 
 ## Additional Information

--- a/docs/team/philbertshea.md
+++ b/docs/team/philbertshea.md
@@ -9,7 +9,7 @@ AddressBook - Level 3 is a desktop address book application used for teaching So
 
 Given below are my contributions to the project.
 
-* **New Feature**: 
+* **New Feature**:
 
 * **Code contributed**: [RepoSense link]()
 


### PR DESCRIPTION
README content was previously catered for the original AB3.

It needs to be repurposed for TAssist.

Let's:
* Update README content in accordance to TAssist value proposition.