### PR TITLE
Update edit preamble

### DIFF
--- a/src/main/java/seedu/tassist/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/tassist/logic/commands/EditCommand.java
@@ -3,6 +3,7 @@ package seedu.tassist.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.tassist.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.tassist.logic.parser.CliSyntax.PREFIX_FACULTY;
+import static seedu.tassist.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.tassist.logic.parser.CliSyntax.PREFIX_LAB_GROUP;
 import static seedu.tassist.logic.parser.CliSyntax.PREFIX_MAT_NUM;
 import static seedu.tassist.logic.parser.CliSyntax.PREFIX_NAME;
@@ -50,7 +51,7 @@ public class EditCommand extends Command {
     public static final String COMMAND_WORD = "edit";
 
     public static final String MESSAGE_USAGE = String.format(
-            "Usage: edit INDEX [OPTIONS]...\n\n"
+            "Usage: edit %s INDEX [OPTIONS]...\n\n"
                     + "Edits the details of a person identified by INDEX in the displayed list.\n"
                     + "Existing values will be overwritten.\n\n"
                     + "Options:\n"
@@ -65,11 +66,12 @@ public class EditCommand extends Command {
                     + "  %-7s YEAR      Update academic year\n"
                     + "  %-7s REMARKS   Update remarks\n"
                     + "  %-7s TAG       Add/update tags (multiple allowed)\n",
-            PREFIX_NAME, PREFIX_PHONE, PREFIX_TELE_HANDLE, PREFIX_EMAIL, PREFIX_MAT_NUM,
+            PREFIX_INDEX, PREFIX_NAME, PREFIX_PHONE, PREFIX_TELE_HANDLE, PREFIX_EMAIL, PREFIX_MAT_NUM,
             PREFIX_TUT_GROUP, PREFIX_LAB_GROUP, PREFIX_FACULTY, PREFIX_YEAR, PREFIX_REMARK, PREFIX_TAG
             )
             + "\nExample:  \n"
-            + "  edit 2 "
+            + "  edit "
+            + PREFIX_INDEX + " 2 "
             + PREFIX_NAME + " John "
             + PREFIX_PHONE + " 98765432 "
             + PREFIX_TELE_HANDLE + " @johnDoe "

--- a/src/main/java/seedu/tassist/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/tassist/logic/parser/EditCommandParser.java
@@ -1,7 +1,6 @@
 package seedu.tassist.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.tassist.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.tassist.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.tassist.logic.parser.CliSyntax.PREFIX_FACULTY;
 import static seedu.tassist.logic.parser.CliSyntax.PREFIX_INDEX;

--- a/src/main/java/seedu/tassist/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/tassist/logic/parser/EditCommandParser.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.tassist.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.tassist.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.tassist.logic.parser.CliSyntax.PREFIX_FACULTY;
+import static seedu.tassist.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.tassist.logic.parser.CliSyntax.PREFIX_LAB_GROUP;
 import static seedu.tassist.logic.parser.CliSyntax.PREFIX_MAT_NUM;
 import static seedu.tassist.logic.parser.CliSyntax.PREFIX_NAME;
@@ -39,7 +40,7 @@ public class EditCommandParser implements Parser<EditCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args,
-                        PREFIX_NAME, PREFIX_PHONE, PREFIX_TELE_HANDLE, PREFIX_EMAIL,
+                        PREFIX_INDEX, PREFIX_NAME, PREFIX_PHONE, PREFIX_TELE_HANDLE, PREFIX_EMAIL,
                         PREFIX_MAT_NUM, PREFIX_TUT_GROUP, PREFIX_LAB_GROUP, PREFIX_FACULTY,
                         PREFIX_YEAR, PREFIX_REMARK, PREFIX_TAG
                 );
@@ -47,14 +48,13 @@ public class EditCommandParser implements Parser<EditCommand> {
         Index index;
 
         try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_INDEX).orElse(""));
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    EditCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(Index.MESSAGE_CONSTRAINTS, pe);
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(
-                PREFIX_NAME, PREFIX_PHONE, PREFIX_TELE_HANDLE, PREFIX_EMAIL,
+                PREFIX_INDEX, PREFIX_NAME, PREFIX_PHONE, PREFIX_TELE_HANDLE, PREFIX_EMAIL,
                 PREFIX_MAT_NUM, PREFIX_TUT_GROUP, PREFIX_LAB_GROUP, PREFIX_FACULTY,
                 PREFIX_YEAR, PREFIX_REMARK
         );

--- a/src/test/java/seedu/tassist/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/tassist/logic/commands/EditPersonDescriptorTest.java
@@ -89,7 +89,6 @@ public class EditPersonDescriptorTest {
 
     @Test
     public void toStringMethod() {
-        // todo: Wei En
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
         String expected = EditPersonDescriptor.class.getCanonicalName() + "{name="
                 + editPersonDescriptor.getName().orElse(null) + ", phone="

--- a/src/test/java/seedu/tassist/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/tassist/logic/parser/AddressBookParserTest.java
@@ -61,6 +61,7 @@ public class AddressBookParserTest {
         Person person = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
+                + PREFIX_INDEX + " "
                 + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
         assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
     }

--- a/src/test/java/seedu/tassist/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/tassist/logic/parser/EditCommandParserTest.java
@@ -92,86 +92,86 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
-        String userInputBegining = " " + PREFIX_INDEX + " 1";
+        String firstPersonIndex = " " + PREFIX_INDEX + " 1";
         assertParseFailure(parser, " " + PREFIX_INDEX + " -10", Index.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, userInputBegining + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
-        assertParseFailure(parser, userInputBegining + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
+        assertParseFailure(parser, firstPersonIndex + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
+        assertParseFailure(parser, firstPersonIndex + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
         // invalid tele handle
         assertParseFailure(parser,
-                userInputBegining + INVALID_TELE_HANDLE_DESC, TeleHandle.MESSAGE_CONSTRAINTS
+                firstPersonIndex + INVALID_TELE_HANDLE_DESC, TeleHandle.MESSAGE_CONSTRAINTS
         );
-        assertParseFailure(parser, userInputBegining + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
+        assertParseFailure(parser, firstPersonIndex + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
         // invalid mat_num
         assertParseFailure(parser,
-                userInputBegining + INVALID_MAT_NUM_DESC, MatNum.MESSAGE_CONSTRAINTS
+                firstPersonIndex + INVALID_MAT_NUM_DESC, MatNum.MESSAGE_CONSTRAINTS
         );
         // invalid tut_group
         assertParseFailure(parser,
-                userInputBegining + INVALID_TUT_GROUP_DESC, TutGroup.MESSAGE_CONSTRAINTS
+                firstPersonIndex + INVALID_TUT_GROUP_DESC, TutGroup.MESSAGE_CONSTRAINTS
         );
         // invalid lab_group
         assertParseFailure(parser,
-                userInputBegining + INVALID_LAB_GROUP_DESC, LabGroup.MESSAGE_CONSTRAINTS
+                firstPersonIndex + INVALID_LAB_GROUP_DESC, LabGroup.MESSAGE_CONSTRAINTS
         );
         // invalid faculty
         assertParseFailure(parser,
-                userInputBegining + INVALID_FACULTY_DESC, Faculty.MESSAGE_CONSTRAINTS
+                firstPersonIndex + INVALID_FACULTY_DESC, Faculty.MESSAGE_CONSTRAINTS
         );
-        assertParseFailure(parser, userInputBegining + INVALID_YEAR_DESC, Year.MESSAGE_CONSTRAINTS); // invalid year
-        assertParseFailure(parser, userInputBegining + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
+        assertParseFailure(parser, firstPersonIndex + INVALID_YEAR_DESC, Year.MESSAGE_CONSTRAINTS); // invalid year
+        assertParseFailure(parser, firstPersonIndex + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
         // assertParseFailure(parser, "1" + INVALID_REMARK_DESC,
         //      Remark.MESSAGE_CONSTRAINTS); // invalid remark (TODO: Zhen Jie to update)
 
         // ================= Dont know if this is correct =================
         // invalid phone followed by valid email
-        assertParseFailure(parser, userInputBegining + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, firstPersonIndex + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
         // invalid name with valid phone
-        assertParseFailure(parser, userInputBegining + INVALID_NAME_DESC + PHONE_DESC_AMY, Name.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, firstPersonIndex + INVALID_NAME_DESC + PHONE_DESC_AMY, Name.MESSAGE_CONSTRAINTS);
         // invalid phone with valid email
-        assertParseFailure(parser, userInputBegining + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, firstPersonIndex + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
         // invalid tele handle with valid matric number
         assertParseFailure(parser,
-                userInputBegining + INVALID_TELE_HANDLE_DESC + MAT_NUM_DESC_AMY, TeleHandle.MESSAGE_CONSTRAINTS
+                firstPersonIndex + INVALID_TELE_HANDLE_DESC + MAT_NUM_DESC_AMY, TeleHandle.MESSAGE_CONSTRAINTS
         );
         // invalid email with valid tutorial group
         assertParseFailure(parser,
-                userInputBegining + INVALID_EMAIL_DESC + TUT_GROUP_DESC_AMY, Email.MESSAGE_CONSTRAINTS
+                firstPersonIndex + INVALID_EMAIL_DESC + TUT_GROUP_DESC_AMY, Email.MESSAGE_CONSTRAINTS
         );
         // invalid matric number with valid lab group
         assertParseFailure(parser,
-                userInputBegining + INVALID_MAT_NUM_DESC + LAB_GROUP_DESC_AMY, MatNum.MESSAGE_CONSTRAINTS
+                firstPersonIndex + INVALID_MAT_NUM_DESC + LAB_GROUP_DESC_AMY, MatNum.MESSAGE_CONSTRAINTS
         );
         // invalid tutorial group with valid faculty
         assertParseFailure(parser,
-                userInputBegining + INVALID_TUT_GROUP_DESC + FACULTY_DESC_AMY, TutGroup.MESSAGE_CONSTRAINTS
+                firstPersonIndex + INVALID_TUT_GROUP_DESC + FACULTY_DESC_AMY, TutGroup.MESSAGE_CONSTRAINTS
         );
         // invalid lab group with valid year
         assertParseFailure(parser,
-                userInputBegining + INVALID_LAB_GROUP_DESC + YEAR_DESC_AMY, LabGroup.MESSAGE_CONSTRAINTS
+                firstPersonIndex + INVALID_LAB_GROUP_DESC + YEAR_DESC_AMY, LabGroup.MESSAGE_CONSTRAINTS
         );
         // invalid faculty with valid remark
         assertParseFailure(parser,
-                userInputBegining + INVALID_FACULTY_DESC + REMARK_DESC_AMY, Faculty.MESSAGE_CONSTRAINTS
+                firstPersonIndex + INVALID_FACULTY_DESC + REMARK_DESC_AMY, Faculty.MESSAGE_CONSTRAINTS
         );
         // invalid year with valid tag
-        assertParseFailure(parser, userInputBegining + INVALID_YEAR_DESC + TAG_DESC_FRIEND, Year.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, firstPersonIndex + INVALID_YEAR_DESC + TAG_DESC_FRIEND, Year.MESSAGE_CONSTRAINTS);
         // invalid tag with valid name
-        assertParseFailure(parser, userInputBegining + INVALID_TAG_DESC + NAME_DESC_AMY, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, firstPersonIndex + INVALID_TAG_DESC + NAME_DESC_AMY, Tag.MESSAGE_CONSTRAINTS);
 
         // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Person} being edited,
         // parsing it together with a valid tag results in error
         assertParseFailure(parser,
-                userInputBegining + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS
+                firstPersonIndex + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS
         );
         assertParseFailure(parser,
-                userInputBegining + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS
+                firstPersonIndex + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS
         );
         assertParseFailure(parser,
-                userInputBegining + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS
+                firstPersonIndex + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS
         );
 
         // multiple invalid values, but only the first invalid value is captured
-        assertParseFailure(parser, userInputBegining + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_PHONE_AMY,
+        assertParseFailure(parser, firstPersonIndex + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_PHONE_AMY,
                 Name.MESSAGE_CONSTRAINTS);
     }
 

--- a/src/test/java/seedu/tassist/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/tassist/logic/parser/EditCommandParserTest.java
@@ -41,6 +41,7 @@ import static seedu.tassist.logic.commands.CommandTestUtil.VALID_TUT_GROUP_AMY;
 import static seedu.tassist.logic.commands.CommandTestUtil.VALID_YEAR_AMY;
 import static seedu.tassist.logic.commands.CommandTestUtil.YEAR_DESC_AMY;
 import static seedu.tassist.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.tassist.logic.parser.CliSyntax.PREFIX_INDEX;
 import static seedu.tassist.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.tassist.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.tassist.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -78,86 +79,106 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_missingParts_failure() {
+        // TODO: Might need to check all this again
         // no index specified
-        assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, PREFIX_PHONE + " " + VALID_PHONE_AMY, Index.MESSAGE_CONSTRAINTS);
 
         // no field specified
-        assertParseFailure(parser, "1", EditCommand.MESSAGE_NOT_EDITED);
+        assertParseFailure(parser, " " + PREFIX_INDEX + " 1", EditCommand.MESSAGE_NOT_EDITED);
 
         // no index and no field specified
-        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
-    }
-
-    @Test
-    public void parse_invalidPreamble_failure() {
-        // negative index
-        assertParseFailure(parser, "-5" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
-
-        // zero index
-        assertParseFailure(parser, "0" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
-
-        // invalid arguments being parsed as preamble
-        assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);
-
-        // invalid prefix being parsed as preamble
-        assertParseFailure(parser, "1 i/ string", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, " " + PREFIX_INDEX, Index.MESSAGE_CONSTRAINTS);
     }
 
     @Test
     public void parse_invalidValue_failure() {
-        assertParseFailure(parser, "1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
-        assertParseFailure(parser, "1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
-        assertParseFailure(parser, "1" + INVALID_TELE_HANDLE_DESC,
-                TeleHandle.MESSAGE_CONSTRAINTS); // invalid tele handle
-        assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
-        assertParseFailure(parser, "1" + INVALID_MAT_NUM_DESC, MatNum.MESSAGE_CONSTRAINTS); // invalid mat_num
-        assertParseFailure(parser, "1" + INVALID_TUT_GROUP_DESC, TutGroup.MESSAGE_CONSTRAINTS); // invalid tut_group
-        assertParseFailure(parser, "1" + INVALID_LAB_GROUP_DESC, LabGroup.MESSAGE_CONSTRAINTS); // invalid lab_group
-        assertParseFailure(parser, "1" + INVALID_FACULTY_DESC, Faculty.MESSAGE_CONSTRAINTS); // invalid faculty
-        assertParseFailure(parser, "1" + INVALID_YEAR_DESC, Year.MESSAGE_CONSTRAINTS); // invalid year
-        assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
+        String userInputBegining = " " + PREFIX_INDEX + " 1";
+        assertParseFailure(parser, " " + PREFIX_INDEX + " -10", Index.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, userInputBegining + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
+        assertParseFailure(parser, userInputBegining + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
+        // invalid tele handle
+        assertParseFailure(parser,
+                userInputBegining + INVALID_TELE_HANDLE_DESC, TeleHandle.MESSAGE_CONSTRAINTS
+        );
+        assertParseFailure(parser, userInputBegining + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
+        // invalid mat_num
+        assertParseFailure(parser,
+                userInputBegining + INVALID_MAT_NUM_DESC, MatNum.MESSAGE_CONSTRAINTS
+        );
+        // invalid tut_group
+        assertParseFailure(parser,
+                userInputBegining + INVALID_TUT_GROUP_DESC, TutGroup.MESSAGE_CONSTRAINTS
+        );
+        // invalid lab_group
+        assertParseFailure(parser,
+                userInputBegining + INVALID_LAB_GROUP_DESC, LabGroup.MESSAGE_CONSTRAINTS
+        );
+        // invalid faculty
+        assertParseFailure(parser,
+                userInputBegining + INVALID_FACULTY_DESC, Faculty.MESSAGE_CONSTRAINTS
+        );
+        assertParseFailure(parser, userInputBegining + INVALID_YEAR_DESC, Year.MESSAGE_CONSTRAINTS); // invalid year
+        assertParseFailure(parser, userInputBegining + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
         // assertParseFailure(parser, "1" + INVALID_REMARK_DESC,
         //      Remark.MESSAGE_CONSTRAINTS); // invalid remark (TODO: Zhen Jie to update)
 
         // ================= Dont know if this is correct =================
         // invalid phone followed by valid email
-        assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, userInputBegining + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
         // invalid name with valid phone
-        assertParseFailure(parser, "1" + INVALID_NAME_DESC + PHONE_DESC_AMY, Name.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, userInputBegining + INVALID_NAME_DESC + PHONE_DESC_AMY, Name.MESSAGE_CONSTRAINTS);
         // invalid phone with valid email
-        assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, userInputBegining + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
         // invalid tele handle with valid matric number
-        assertParseFailure(parser, "1" + INVALID_TELE_HANDLE_DESC + MAT_NUM_DESC_AMY, TeleHandle.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser,
+                userInputBegining + INVALID_TELE_HANDLE_DESC + MAT_NUM_DESC_AMY, TeleHandle.MESSAGE_CONSTRAINTS
+        );
         // invalid email with valid tutorial group
-        assertParseFailure(parser, "1" + INVALID_EMAIL_DESC + TUT_GROUP_DESC_AMY, Email.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser,
+                userInputBegining + INVALID_EMAIL_DESC + TUT_GROUP_DESC_AMY, Email.MESSAGE_CONSTRAINTS
+        );
         // invalid matric number with valid lab group
-        assertParseFailure(parser, "1" + INVALID_MAT_NUM_DESC + LAB_GROUP_DESC_AMY, MatNum.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser,
+                userInputBegining + INVALID_MAT_NUM_DESC + LAB_GROUP_DESC_AMY, MatNum.MESSAGE_CONSTRAINTS
+        );
         // invalid tutorial group with valid faculty
-        assertParseFailure(parser, "1" + INVALID_TUT_GROUP_DESC + FACULTY_DESC_AMY, TutGroup.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser,
+                userInputBegining + INVALID_TUT_GROUP_DESC + FACULTY_DESC_AMY, TutGroup.MESSAGE_CONSTRAINTS
+        );
         // invalid lab group with valid year
-        assertParseFailure(parser, "1" + INVALID_LAB_GROUP_DESC + YEAR_DESC_AMY, LabGroup.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser,
+                userInputBegining + INVALID_LAB_GROUP_DESC + YEAR_DESC_AMY, LabGroup.MESSAGE_CONSTRAINTS
+        );
         // invalid faculty with valid remark
-        assertParseFailure(parser, "1" + INVALID_FACULTY_DESC + REMARK_DESC_AMY, Faculty.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser,
+                userInputBegining + INVALID_FACULTY_DESC + REMARK_DESC_AMY, Faculty.MESSAGE_CONSTRAINTS
+        );
         // invalid year with valid tag
-        assertParseFailure(parser, "1" + INVALID_YEAR_DESC + TAG_DESC_FRIEND, Year.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, userInputBegining + INVALID_YEAR_DESC + TAG_DESC_FRIEND, Year.MESSAGE_CONSTRAINTS);
         // invalid tag with valid name
-        assertParseFailure(parser, "1" + INVALID_TAG_DESC + NAME_DESC_AMY, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, userInputBegining + INVALID_TAG_DESC + NAME_DESC_AMY, Tag.MESSAGE_CONSTRAINTS);
 
         // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Person} being edited,
         // parsing it together with a valid tag results in error
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, "1" + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser,
+                userInputBegining + TAG_DESC_FRIEND + TAG_DESC_HUSBAND + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS
+        );
+        assertParseFailure(parser,
+                userInputBegining + TAG_DESC_FRIEND + TAG_EMPTY + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS
+        );
+        assertParseFailure(parser,
+                userInputBegining + TAG_EMPTY + TAG_DESC_FRIEND + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS
+        );
 
         // multiple invalid values, but only the first invalid value is captured
-        assertParseFailure(parser, "1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_PHONE_AMY,
+        assertParseFailure(parser, userInputBegining + INVALID_NAME_DESC + INVALID_EMAIL_DESC + VALID_PHONE_AMY,
                 Name.MESSAGE_CONSTRAINTS);
     }
 
     @Test
     public void parse_allFieldsSpecified_success() {
         Index targetIndex = INDEX_SECOND_PERSON;
-        String userInput = targetIndex.getOneBased()
+        String userInput = " " + PREFIX_INDEX + " " + targetIndex.getOneBased()
                 + TELE_HANDLE_DESC_AMY + YEAR_DESC_AMY + REMARK_DESC_AMY
                 + FACULTY_DESC_AMY + LAB_GROUP_DESC_AMY + MAT_NUM_DESC_BOB
                 + TUT_GROUP_DESC_AMY + PHONE_DESC_BOB + TAG_DESC_HUSBAND
@@ -182,7 +203,7 @@ public class EditCommandParserTest {
     @Test
     public void parse_someFieldsSpecified_success() {
         Index targetIndex = INDEX_FIRST_PERSON;
-        String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + EMAIL_DESC_AMY;
+        String userInput = " " + PREFIX_INDEX + " " + targetIndex.getOneBased() + PHONE_DESC_BOB + EMAIL_DESC_AMY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withPhone(VALID_PHONE_BOB)
                 .withEmail(VALID_EMAIL_AMY).build();
@@ -223,7 +244,7 @@ public class EditCommandParserTest {
      * Helper method to assert parsing success for a single field edit.
      */
     private void assertSingleFieldEdit(Index targetIndex, String userInputSuffix, EditPersonDescriptor descriptor) {
-        String userInput = targetIndex.getOneBased() + userInputSuffix;
+        String userInput = " " + PREFIX_INDEX + " " + targetIndex.getOneBased() + userInputSuffix;
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -235,17 +256,17 @@ public class EditCommandParserTest {
 
         // valid followed by invalid
         Index targetIndex = INDEX_FIRST_PERSON;
-        String userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + PHONE_DESC_BOB;
+        String userInput = " " + PREFIX_INDEX + " " + targetIndex.getOneBased() + INVALID_PHONE_DESC + PHONE_DESC_BOB;
 
         assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
 
         // invalid followed by valid
-        userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + INVALID_PHONE_DESC;
+        userInput = " " + PREFIX_INDEX + " " + targetIndex.getOneBased() + PHONE_DESC_BOB + INVALID_PHONE_DESC;
 
         assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
 
-        // mulltiple valid fields repeated
-        userInput = targetIndex.getOneBased() + PHONE_DESC_AMY + EMAIL_DESC_AMY
+        // multiple valid fields repeated
+        userInput = " " + PREFIX_INDEX + " " + targetIndex.getOneBased() + PHONE_DESC_AMY + EMAIL_DESC_AMY
                 + TAG_DESC_FRIEND + PHONE_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
                 + PHONE_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;
 
@@ -253,7 +274,7 @@ public class EditCommandParserTest {
                 Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL));
 
         // multiple invalid values
-        userInput = targetIndex.getOneBased() + INVALID_PHONE_DESC + INVALID_EMAIL_DESC
+        userInput = " " + PREFIX_INDEX + " " + targetIndex.getOneBased() + INVALID_PHONE_DESC + INVALID_EMAIL_DESC
                 + INVALID_PHONE_DESC + INVALID_EMAIL_DESC;
 
         assertParseFailure(parser, userInput,
@@ -263,7 +284,7 @@ public class EditCommandParserTest {
     @Test
     public void parse_resetTags_success() {
         Index targetIndex = INDEX_THIRD_PERSON;
-        String userInput = targetIndex.getOneBased() + TAG_EMPTY;
+        String userInput = " " + PREFIX_INDEX + " " + targetIndex.getOneBased() + TAG_EMPTY;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withTags().build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);


### PR DESCRIPTION
Removed the preemble for the edit command and replaced it with the -i flag.

This is part of the efforts to standardise the inputs across all commands.
Closes #106 