### PR TITLE
Update matriculation number information

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -13,7 +13,8 @@
 
 ## **Acknowledgements**
 
-This project was adapted from [AB3](https://se-education.org/addressbook-level3/) (source code provided [here](https://github.com/nus-cs2103-AY2425S2/tp))
+This project was adapted from [AB3](https://se-education.org/addressbook-level3/) (source code provided [here](https://github.com/nus-cs2103-AY2425S2/tp)).
+This project adapts the matriculation number checksum from [here](https://nusmodifications.github.io/nus-matriculation-number-calculator/) (source code provided [here](https://github.com/nusmodifications/nus-matriculation-number-calculator/blob/gh-pages/matric.js)).
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -91,6 +91,12 @@ Format: `add -n NAME (-p PHONE_NUMBER -tg TELEGRAM_HANDLE) -e EMAIL -m MATRICULA
 
 <box type="tip" seamless>
 
+**Tip:** Matriculation numbers follows a checksum rule!
+See [here](https://nusmodifications.github.io/nus-matriculation-number-calculator/) for a matriculation number calculator.
+</box>
+
+<box type="tip" seamless>
+
 **Tip:** A person can have any number of tags (including 0).
 Tags must be a single word consisting of alphanumeric characters only.
 </box>

--- a/src/main/java/seedu/tassist/model/person/MatNum.java
+++ b/src/main/java/seedu/tassist/model/person/MatNum.java
@@ -12,8 +12,9 @@ public class MatNum {
 
     public static final String MESSAGE_CONSTRAINTS = "Invalid matriculation number!"
             + "\nMatriculation numbers should start with 'A' and contain 7 digits minimally."
-            + "\nThe last character of the matriculation number will"
-            + "be automatically generated if not provided.";
+            + "\nThe last character follows a checksum rule.\n"
+            + "If you are unsure about the checksum character, enter the first 8 characters \n"
+            + " and the system will complete it for you!";
 
     public static final String VALIDATION_REGEX = "^[Aa]\\d{7}[A-Za-z]?$";
 


### PR DESCRIPTION
Currently, matriculation number follows a checksum rule.

However, this knowledge may not be known to users.

Let's:
* Inform the users that it follows a checksum rule.
* Inform the users that the last character may be omitted
* Update the DG and the UG
closes #137 