### PR TITLE
Enable Assertions for build.gradle file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ test {
 
 run {
     jvmArgs '-ea'
+    enableAssertions = true
 }
 
 task coverage(type: JacocoReport) {


### PR DESCRIPTION
Build.gradle file does not have assertions enabled.

Let's
* Enable assertions on build.gradle file

Closes #162.