### PR TITLE
Bug Fix: Standardise tag ordering

### DIFF
--- a/src/main/java/seedu/tassist/logic/Messages.java
+++ b/src/main/java/seedu/tassist/logic/Messages.java
@@ -2,13 +2,11 @@ package seedu.tassist.logic;
 
 import java.util.Comparator;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.tassist.logic.parser.Prefix;
 import seedu.tassist.model.person.Person;
-import seedu.tassist.model.tag.Tag;
 
 /**
  * Container for user visible messages.

--- a/src/main/java/seedu/tassist/logic/Messages.java
+++ b/src/main/java/seedu/tassist/logic/Messages.java
@@ -1,11 +1,14 @@
 package seedu.tassist.logic;
 
+import java.util.Comparator;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.tassist.logic.parser.Prefix;
 import seedu.tassist.model.person.Person;
+import seedu.tassist.model.tag.Tag;
 
 /**
  * Container for user visible messages.
@@ -121,7 +124,10 @@ public class Messages {
                 .append(person.getRemark().value.isEmpty() ? "-" : person.getRemark())
                 .append("\n")
                 .append(" Tags              : ");
-        person.getTags().forEach(builder::append);
+
+        // Display the sorting of tags
+        person.getTags().stream()
+                .sorted(Comparator.comparing(tag -> tag.tagName)).forEach(builder::append);
         return builder.toString();
     }
 


### PR DESCRIPTION
Closes #184 

This standardises the ordering of tags displayed after the command is successfully executed.

### Command Executed:
`tag -a -i 3 -tag tag123 -tag u -tag lol -tag hehe -tag whatIsThis -tag NICE
`
### Result:
![image](https://github.com/user-attachments/assets/ced969b2-72ef-4982-927d-39dfafd9979a)
