### PR TITLE
Update MarkAttendanceCommand errors to be more useful

### DIFF
--- a/src/main/java/seedu/tassist/logic/commands/MarkAttendanceCommand.java
+++ b/src/main/java/seedu/tassist/logic/commands/MarkAttendanceCommand.java
@@ -211,10 +211,18 @@ public class MarkAttendanceCommand extends Command {
                         String.format(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, lastShownList.size()));
             }
             personsToEdit = new ArrayList<>();
+            StringBuilder invalidPersonsErrorMessage = new StringBuilder();
             for (Index index : indexList) {
                 Person personToEdit = lastShownList.get(index.getZeroBased());
-                this.checkIfIndexFlagCommandValid(personToEdit);
-                personsToEdit.add(personToEdit);
+                try {
+                    this.checkIfIndexFlagCommandValid(personToEdit);
+                    personsToEdit.add(personToEdit);
+                } catch (CommandException e) {
+                    invalidPersonsErrorMessage.append(e.getMessage());
+                }
+            }
+            if (!invalidPersonsErrorMessage.toString().isEmpty()) {
+                throw new CommandException(invalidPersonsErrorMessage.toString());
             }
         }
 
@@ -273,7 +281,7 @@ public class MarkAttendanceCommand extends Command {
 
     /**
      * Generates a command execution success message for
-     * {@code personToEdit}.
+     * {@code tutGroupsToEdit}.
      *
      * @return String with the Success Message once MarkAttendanceCommand
      *         is executed successfully.

--- a/src/main/java/seedu/tassist/ui/PersonListPanel.java
+++ b/src/main/java/seedu/tassist/ui/PersonListPanel.java
@@ -4,12 +4,14 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
 
+import javafx.animation.FadeTransition;
 import javafx.beans.property.BooleanProperty;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
+import javafx.util.Duration;
 import seedu.tassist.commons.core.LogsCenter;
 import seedu.tassist.model.person.Person;
 
@@ -65,7 +67,11 @@ public class PersonListPanel extends UiPart<Region> {
                 displayedCards.remove(person);
             } else {
                 PersonCard personCard = new PersonCard(person, getIndex() + 1);
+                personCard.getRoot().setOpacity(0);
                 setGraphic(personCard.getRoot());
+                FadeTransition fade = new FadeTransition(Duration.millis(200), personCard.getRoot());
+                fade.setToValue(1);
+                fade.play();
 
                 boolean isCompactView = compactView.get();
                 boolean isSelected = getListView().getSelectionModel().getSelectedItem() == person;


### PR DESCRIPTION
Error messages involving invalid index commands should show all the individuals who do not fulfill the restrictions.

This would be more useful to the user.

Also, fade transition could be used to make the user experience better.

Let's

* Update the MarkAttendanceCommand file to support this.
* Update the PersonListPanel file to support this.

Closes #298.
Closes #271.